### PR TITLE
feat: Add automated formula update workflow

### DIFF
--- a/.github/workflows/update-formula.yml
+++ b/.github/workflows/update-formula.yml
@@ -1,0 +1,243 @@
+name: Update Formula Version
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to update (e.g., 0.0.1-alpha, 0.1.0, 1.0.0-rc.1)'
+        required: true
+        type: string
+      formula:
+        description: 'Formula to update'
+        required: true
+        type: choice
+        options:
+          - kecs
+          - kecs-dev
+          - both
+        default: kecs
+      skip_sha_validation:
+        description: 'Skip SHA256 validation (for testing only)'
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  update-formula:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Validate version format
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          # Remove 'v' prefix if present
+          VERSION="${VERSION#v}"
+          
+          # Validate semantic versioning with optional pre-release
+          if ! echo "$VERSION" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+(\.[0-9]+)?)?$'; then
+            echo "Error: Invalid version format. Expected format: X.Y.Z or X.Y.Z-prerelease"
+            echo "Examples: 0.0.1, 1.0.0, 0.0.1-alpha, 1.0.0-beta.1, 2.0.0-rc.1"
+            exit 1
+          fi
+          
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "Valid version: $VERSION"
+
+      - name: Check if release exists
+        id: check_release
+        run: |
+          VERSION="${{ env.VERSION }}"
+          RELEASE_URL="https://api.github.com/repos/nandemo-ya/kecs/releases/tags/v${VERSION}"
+          
+          echo "Checking release at: $RELEASE_URL"
+          
+          if curl -s -f -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "$RELEASE_URL" > /dev/null 2>&1; then
+            echo "Release v${VERSION} found"
+            echo "release_exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "Warning: Release v${VERSION} not found in nandemo-ya/kecs"
+            echo "release_exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Calculate SHA256 hashes
+        if: steps.check_release.outputs.release_exists == 'true' || github.event.inputs.skip_sha_validation == 'true'
+        run: |
+          VERSION="${{ env.VERSION }}"
+          
+          # Define platforms
+          declare -A PLATFORMS=(
+            ["darwin_amd64"]="Darwin_x86_64"
+            ["darwin_arm64"]="Darwin_arm64"
+            ["linux_amd64"]="Linux_x86_64"
+            ["linux_arm64"]="Linux_arm64"
+          )
+          
+          # Download and calculate SHA256 for each platform
+          for key in "${!PLATFORMS[@]}"; do
+            FILENAME="kecs_v${VERSION}_${PLATFORMS[$key]}.tar.gz"
+            URL="https://github.com/nandemo-ya/kecs/releases/download/v${VERSION}/${FILENAME}"
+            
+            echo "Processing ${PLATFORMS[$key]}..."
+            
+            if curl -sL -f "$URL" -o "/tmp/${FILENAME}" 2>/dev/null; then
+              SHA256=$(sha256sum "/tmp/${FILENAME}" | cut -d' ' -f1)
+              echo "SHA256_${key}=${SHA256}" >> $GITHUB_ENV
+              echo "  SHA256: ${SHA256}"
+              rm "/tmp/${FILENAME}"
+            else
+              if [[ "${{ github.event.inputs.skip_sha_validation }}" == "true" ]]; then
+                echo "SHA256_${key}=PLACEHOLDER" >> $GITHUB_ENV
+                echo "  SHA256: PLACEHOLDER (file not found, validation skipped)"
+              else
+                echo "  Error: Failed to download ${FILENAME}"
+                exit 1
+              fi
+            fi
+          done
+
+      - name: Update kecs formula
+        if: github.event.inputs.formula == 'kecs' || github.event.inputs.formula == 'both'
+        run: |
+          VERSION="${{ env.VERSION }}"
+          FORMULA_FILE="Formula/kecs.rb"
+          
+          echo "Updating $FORMULA_FILE to version $VERSION"
+          
+          # Create temporary file with updated content
+          cat > /tmp/formula_update.rb << 'EOF'
+          #!/usr/bin/env ruby
+          
+          version = ENV['VERSION']
+          sha_darwin_amd64 = ENV['SHA256_darwin_amd64']
+          sha_darwin_arm64 = ENV['SHA256_darwin_arm64']
+          sha_linux_amd64 = ENV['SHA256_linux_amd64']
+          sha_linux_arm64 = ENV['SHA256_linux_arm64']
+          
+          formula = File.read(ARGV[0])
+          
+          # Update version
+          formula.gsub!(/version ".*"/, "version \"#{version}\"")
+          
+          # Update URLs and SHA256
+          formula.gsub!(/url ".*Darwin_x86_64.*"/, "url \"https://github.com/nandemo-ya/kecs/releases/download/v#{version}/kecs_v#{version}_Darwin_x86_64.tar.gz\"")
+          formula.gsub!(/url ".*Darwin_arm64.*"/, "url \"https://github.com/nandemo-ya/kecs/releases/download/v#{version}/kecs_v#{version}_Darwin_arm64.tar.gz\"")
+          formula.gsub!(/url ".*Linux_x86_64.*"/, "url \"https://github.com/nandemo-ya/kecs/releases/download/v#{version}/kecs_v#{version}_Linux_x86_64.tar.gz\"")
+          formula.gsub!(/url ".*Linux_arm64.*"/, "url \"https://github.com/nandemo-ya/kecs/releases/download/v#{version}/kecs_v#{version}_Linux_arm64.tar.gz\"")
+          
+          # Update SHA256 - handle multiline context
+          lines = formula.split("\n")
+          lines.each_with_index do |line, i|
+            if line.include?("Darwin_x86_64")
+              # Find the next sha256 line
+              (i+1..i+3).each do |j|
+                if lines[j] && lines[j].include?("sha256")
+                  lines[j] = "      sha256 \"#{sha_darwin_amd64}\""
+                  break
+                end
+              end
+            elsif line.include?("Darwin_arm64")
+              (i+1..i+3).each do |j|
+                if lines[j] && lines[j].include?("sha256")
+                  lines[j] = "      sha256 \"#{sha_darwin_arm64}\""
+                  break
+                end
+              end
+            elsif line.include?("Linux_x86_64")
+              (i+1..i+3).each do |j|
+                if lines[j] && lines[j].include?("sha256")
+                  lines[j] = "      sha256 \"#{sha_linux_amd64}\""
+                  break
+                end
+              end
+            elsif line.include?("Linux_arm64")
+              (i+1..i+3).each do |j|
+                if lines[j] && lines[j].include?("sha256")
+                  lines[j] = "      sha256 \"#{sha_linux_arm64}\""
+                  break
+                end
+              end
+            end
+          end
+          
+          File.write(ARGV[0], lines.join("\n"))
+          EOF
+          
+          chmod +x /tmp/formula_update.rb
+          ruby /tmp/formula_update.rb "$FORMULA_FILE"
+          
+          echo "Updated $FORMULA_FILE"
+
+      - name: Update kecs-dev formula
+        if: github.event.inputs.formula == 'kecs-dev' || github.event.inputs.formula == 'both'
+        run: |
+          VERSION="${{ env.VERSION }}"
+          FORMULA_FILE="Formula/kecs-dev.rb"
+          
+          echo "Updating $FORMULA_FILE to version $VERSION"
+          
+          # Use the same update script
+          ruby /tmp/formula_update.rb "$FORMULA_FILE"
+          
+          echo "Updated $FORMULA_FILE"
+
+      - name: Validate formula syntax
+        run: |
+          # Basic Ruby syntax check
+          for formula in Formula/*.rb; do
+            echo "Validating $formula..."
+            ruby -c "$formula"
+          done
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: Update ${{ github.event.inputs.formula }} formula to v${{ env.VERSION }}"
+          title: "Update ${{ github.event.inputs.formula }} formula to v${{ env.VERSION }}"
+          body: |
+            ## Formula Update
+            
+            This PR updates the Homebrew formula(s) to version `v${{ env.VERSION }}`.
+            
+            ### Changes
+            - Formula: `${{ github.event.inputs.formula }}`
+            - Version: `${{ env.VERSION }}`
+            - Release exists: `${{ steps.check_release.outputs.release_exists }}`
+            
+            ### SHA256 Hashes
+            - Darwin x86_64: `${{ env.SHA256_darwin_amd64 }}`
+            - Darwin ARM64: `${{ env.SHA256_darwin_arm64 }}`
+            - Linux x86_64: `${{ env.SHA256_linux_amd64 }}`
+            - Linux ARM64: `${{ env.SHA256_linux_arm64 }}`
+            
+            ### Installation
+            After merging, users can install with:
+            ```bash
+            brew update
+            brew upgrade kecs
+            ```
+            
+            ---
+            *This PR was automatically generated by the update-formula workflow.*
+          branch: formula-update-v${{ env.VERSION }}
+          delete-branch: true
+          labels: |
+            formula-update
+            automated
+
+      - name: Summary
+        run: |
+          echo "## Update Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Version**: v${{ env.VERSION }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Formula**: ${{ github.event.inputs.formula }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Release Status**: ${{ steps.check_release.outputs.release_exists == 'true' && '✅ Found' || '⚠️ Not Found' }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Next Steps" >> $GITHUB_STEP_SUMMARY
+          echo "1. Review the created Pull Request" >> $GITHUB_STEP_SUMMARY
+          echo "2. Verify the SHA256 hashes are correct" >> $GITHUB_STEP_SUMMARY
+          echo "3. Merge the PR to update the formula" >> $GITHUB_STEP_SUMMARY

--- a/scripts/update-formula.sh
+++ b/scripts/update-formula.sh
@@ -1,0 +1,236 @@
+#!/bin/bash
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Function to print colored output
+print_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
+print_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+print_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+
+# Usage function
+usage() {
+    cat << EOF
+Usage: $0 [OPTIONS] VERSION
+
+Update Homebrew formula to a new version.
+
+Arguments:
+  VERSION     Version to update to (e.g., 0.0.1-alpha, 0.1.0, 1.0.0-rc.1)
+
+Options:
+  -f, --formula FORMULA   Formula to update (kecs, kecs-dev, or both) [default: kecs]
+  -s, --skip-download     Skip downloading files for SHA256 calculation
+  -p, --placeholder       Use PLACEHOLDER for SHA256 (for testing)
+  -h, --help             Show this help message
+
+Examples:
+  $0 0.0.1-alpha
+  $0 --formula kecs-dev 0.0.2-beta
+  $0 --formula both 1.0.0
+  $0 --placeholder 0.0.1-dev  # For unreleased versions
+
+EOF
+    exit 1
+}
+
+# Parse arguments
+FORMULA="kecs"
+SKIP_DOWNLOAD=false
+USE_PLACEHOLDER=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -f|--formula)
+            FORMULA="$2"
+            shift 2
+            ;;
+        -s|--skip-download)
+            SKIP_DOWNLOAD=true
+            shift
+            ;;
+        -p|--placeholder)
+            USE_PLACEHOLDER=true
+            shift
+            ;;
+        -h|--help)
+            usage
+            ;;
+        -*)
+            print_error "Unknown option: $1"
+            usage
+            ;;
+        *)
+            VERSION="$1"
+            shift
+            ;;
+    esac
+done
+
+# Check if version is provided
+if [ -z "$VERSION" ]; then
+    print_error "Version is required"
+    usage
+fi
+
+# Remove 'v' prefix if present
+VERSION="${VERSION#v}"
+
+# Validate version format
+if ! echo "$VERSION" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+(\.[0-9]+)?)?$' > /dev/null; then
+    print_error "Invalid version format: $VERSION"
+    print_info "Expected format: X.Y.Z or X.Y.Z-prerelease"
+    print_info "Examples: 0.0.1, 1.0.0, 0.0.1-alpha, 1.0.0-beta.1"
+    exit 1
+fi
+
+print_info "Updating formula to version: v$VERSION"
+
+# Define platforms
+declare -A PLATFORMS=(
+    ["darwin_amd64"]="Darwin_x86_64"
+    ["darwin_arm64"]="Darwin_arm64"
+    ["linux_amd64"]="Linux_x86_64"
+    ["linux_arm64"]="Linux_arm64"
+)
+
+# Calculate SHA256 hashes
+declare -A SHA256_HASHES
+
+if [ "$USE_PLACEHOLDER" = true ]; then
+    print_warn "Using PLACEHOLDER for SHA256 hashes"
+    for key in "${!PLATFORMS[@]}"; do
+        SHA256_HASHES[$key]="PLACEHOLDER"
+    done
+elif [ "$SKIP_DOWNLOAD" = false ]; then
+    print_info "Calculating SHA256 hashes..."
+    
+    for key in "${!PLATFORMS[@]}"; do
+        FILENAME="kecs_v${VERSION}_${PLATFORMS[$key]}.tar.gz"
+        URL="https://github.com/nandemo-ya/kecs/releases/download/v${VERSION}/${FILENAME}"
+        
+        echo -n "  ${PLATFORMS[$key]}: "
+        
+        if curl -sL -f "$URL" -o "/tmp/${FILENAME}" 2>/dev/null; then
+            SHA256=$(sha256sum "/tmp/${FILENAME}" | cut -d' ' -f1)
+            SHA256_HASHES[$key]="$SHA256"
+            echo "$SHA256"
+            rm "/tmp/${FILENAME}"
+        else
+            print_warn "Failed to download ${FILENAME}, using PLACEHOLDER"
+            SHA256_HASHES[$key]="PLACEHOLDER"
+        fi
+    done
+else
+    print_info "Skipping SHA256 calculation"
+    for key in "${!PLATFORMS[@]}"; do
+        SHA256_HASHES[$key]="EXISTING"
+    done
+fi
+
+# Function to update formula file
+update_formula() {
+    local formula_file="$1"
+    
+    if [ ! -f "$formula_file" ]; then
+        print_error "Formula file not found: $formula_file"
+        return 1
+    fi
+    
+    print_info "Updating $formula_file"
+    
+    # Create backup
+    cp "$formula_file" "${formula_file}.bak"
+    
+    # Update version
+    sed -i '' "s/version \".*\"/version \"$VERSION\"/" "$formula_file"
+    
+    # Update URLs
+    sed -i '' "s|download/v[^/]*/kecs_v[^_]*_Darwin_x86_64|download/v${VERSION}/kecs_v${VERSION}_Darwin_x86_64|" "$formula_file"
+    sed -i '' "s|download/v[^/]*/kecs_v[^_]*_Darwin_arm64|download/v${VERSION}/kecs_v${VERSION}_Darwin_arm64|" "$formula_file"
+    sed -i '' "s|download/v[^/]*/kecs_v[^_]*_Linux_x86_64|download/v${VERSION}/kecs_v${VERSION}_Linux_x86_64|" "$formula_file"
+    sed -i '' "s|download/v[^/]*/kecs_v[^_]*_Linux_arm64|download/v${VERSION}/kecs_v${VERSION}_Linux_arm64|" "$formula_file"
+    
+    # Update SHA256 hashes if not skipping
+    if [ "$SKIP_DOWNLOAD" = false ]; then
+        # This is complex due to multiline structure, so we use a Ruby script
+        ruby -e "
+            content = File.read('$formula_file')
+            lines = content.split(\"\\n\")
+            
+            lines.each_with_index do |line, i|
+                if line.include?('Darwin_x86_64')
+                    (i+1..i+3).each do |j|
+                        if lines[j] && lines[j].include?('sha256')
+                            lines[j] = '      sha256 \"${SHA256_HASHES[darwin_amd64]}\"'
+                            break
+                        end
+                    end
+                elsif line.include?('Darwin_arm64')
+                    (i+1..i+3).each do |j|
+                        if lines[j] && lines[j].include?('sha256')
+                            lines[j] = '      sha256 \"${SHA256_HASHES[darwin_arm64]}\"'
+                            break
+                        end
+                    end
+                elsif line.include?('Linux_x86_64')
+                    (i+1..i+3).each do |j|
+                        if lines[j] && lines[j].include?('sha256')
+                            lines[j] = '      sha256 \"${SHA256_HASHES[linux_amd64]}\"'
+                            break
+                        end
+                    end
+                elsif line.include?('Linux_arm64')
+                    (i+1..i+3).each do |j|
+                        if lines[j] && lines[j].include?('sha256')
+                            lines[j] = '      sha256 \"${SHA256_HASHES[linux_arm64]}\"'
+                            break
+                        end
+                    end
+                end
+            end
+            
+            File.write('$formula_file', lines.join(\"\\n\"))
+        "
+    fi
+    
+    # Validate Ruby syntax
+    if ruby -c "$formula_file" > /dev/null 2>&1; then
+        print_info "✅ Formula syntax is valid"
+        rm "${formula_file}.bak"
+    else
+        print_error "Formula syntax validation failed!"
+        mv "${formula_file}.bak" "$formula_file"
+        return 1
+    fi
+}
+
+# Update the specified formula(s)
+case $FORMULA in
+    kecs)
+        update_formula "Formula/kecs.rb"
+        ;;
+    kecs-dev)
+        update_formula "Formula/kecs-dev.rb"
+        ;;
+    both)
+        update_formula "Formula/kecs.rb"
+        update_formula "Formula/kecs-dev.rb"
+        ;;
+    *)
+        print_error "Invalid formula: $FORMULA"
+        print_info "Valid options: kecs, kecs-dev, both"
+        exit 1
+        ;;
+esac
+
+print_info "Formula update complete!"
+print_info ""
+print_info "Next steps:"
+print_info "  1. Review the changes: git diff"
+print_info "  2. Commit the changes: git add -A && git commit -m \"chore: Update $FORMULA to v$VERSION\""
+print_info "  3. Push to repository: git push origin main"


### PR DESCRIPTION
## Summary

This PR adds GitHub Actions workflow and supporting scripts to automate Homebrew formula updates.

## Features

### GitHub Actions Workflow (`.github/workflows/update-formula.yml`)
- **Manual trigger via workflow_dispatch** with version input
- **Supports multiple formulas**: kecs, kecs-dev, or both
- **Automatic SHA256 calculation** from GitHub releases
- **Version validation** for semantic versioning (X.Y.Z and pre-release formats)
- **Creates PR automatically** with all changes for review
- **Release verification** to ensure the version exists in nandemo-ya/kecs

### Local Update Script (`scripts/update-formula.sh`)
- Command-line tool for local formula updates
- Supports the same version formats as the workflow
- Options for placeholder SHA256 (for unreleased versions)
- Automatic syntax validation

## Usage

### Via GitHub Actions
1. Go to Actions tab → "Update Formula Version" workflow
2. Click "Run workflow"
3. Enter version (e.g., `0.0.2-alpha`, `1.0.0`)
4. Select formula to update
5. Review and merge the created PR

### Via Local Script
```bash
# Update kecs formula
./scripts/update-formula.sh 0.0.2-alpha

# Update dev formula
./scripts/update-formula.sh --formula kecs-dev 0.0.3-beta

# Update both formulas
./scripts/update-formula.sh --formula both 1.0.0

# For unreleased version (uses PLACEHOLDER for SHA256)
./scripts/update-formula.sh --placeholder 0.0.1-dev
```

## Supported Version Formats
- Stable: `0.1.0`, `1.0.0`, `2.5.3`
- Alpha: `0.0.1-alpha`, `1.0.0-alpha`
- Beta: `0.1.0-beta`, `1.0.0-beta.1`
- RC: `1.0.0-rc.1`, `2.0.0-rc.3`

## Benefits
- 🚀 **Faster releases** - No manual formula editing required
- 🔒 **Reduced errors** - Automatic SHA256 calculation
- 📝 **PR workflow** - All changes reviewed before merge
- 🔄 **Consistency** - Same process for all version types