### PR TITLE
fix: Fix update workflow script not found error

### DIFF
--- a/.github/workflows/update-formula.yml
+++ b/.github/workflows/update-formula.yml
@@ -25,6 +25,9 @@ on:
 jobs:
   update-formula:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -99,15 +102,9 @@ jobs:
             fi
           done
 
-      - name: Update kecs formula
-        if: github.event.inputs.formula == 'kecs' || github.event.inputs.formula == 'both'
+      - name: Create update script
         run: |
-          VERSION="${{ env.VERSION }}"
-          FORMULA_FILE="Formula/kecs.rb"
-          
-          echo "Updating $FORMULA_FILE to version $VERSION"
-          
-          # Create temporary file with updated content
+          # Create the update script once, to be used by both formula updates
           cat > /tmp/formula_update.rb << 'EOF'
           #!/usr/bin/env ruby
           
@@ -167,8 +164,15 @@ jobs:
           EOF
           
           chmod +x /tmp/formula_update.rb
-          ruby /tmp/formula_update.rb "$FORMULA_FILE"
+
+      - name: Update kecs formula
+        if: github.event.inputs.formula == 'kecs' || github.event.inputs.formula == 'both'
+        run: |
+          VERSION="${{ env.VERSION }}"
+          FORMULA_FILE="Formula/kecs.rb"
           
+          echo "Updating $FORMULA_FILE to version $VERSION"
+          ruby /tmp/formula_update.rb "$FORMULA_FILE"
           echo "Updated $FORMULA_FILE"
 
       - name: Update kecs-dev formula
@@ -178,10 +182,7 @@ jobs:
           FORMULA_FILE="Formula/kecs-dev.rb"
           
           echo "Updating $FORMULA_FILE to version $VERSION"
-          
-          # Use the same update script
           ruby /tmp/formula_update.rb "$FORMULA_FILE"
-          
           echo "Updated $FORMULA_FILE"
 
       - name: Validate formula syntax


### PR DESCRIPTION
## Problem
The update formula workflow was failing with:
```
ruby: No such file or directory -- /tmp/formula_update.rb (LoadError)
```

## Root Cause
The Ruby update script was being created inline during the "Update kecs formula" step. When the workflow tried to update both formulas (kecs and kecs-dev), the script only existed during the first formula update step and was not available for the second.

## Solution
- Created a separate "Create update script" step that runs before any formula updates
- This ensures the script exists for both formula update steps
- The script is created once and reused by both updates

## Testing
After this fix:
1. The script will be created in its own step
2. Both "Update kecs formula" and "Update kecs-dev formula" steps will use the same script
3. The workflow should complete successfully

## Changes
- Moved script creation to a dedicated step
- Simplified the formula update steps to just call the pre-created script